### PR TITLE
Minor fix to build system

### DIFF
--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -45,6 +45,11 @@ on:
         description: base python image to get from dockerhub
         required: false
         type: string
+      build-system-ref:
+        description: github reference of the build system to checkout
+        required: false
+        type: string
+        default: main
   workflow_call:
     inputs:
       target:
@@ -105,6 +110,10 @@ on:
       bst-flow-version:
         required: false
         type: string
+      build-system-ref:
+        required: false
+        type: string
+        default: main
     secrets:
       DOCKER_USERNAME:
         description: 'Image repository on dockerhub to which to push'
@@ -129,7 +138,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: scilus/containers-scilus
-          ref: develop
+          ref: ${{ inputs.build-system-ref }}
       -
         name: Resolve versioning from workflow inputs
         id: local-versioning

--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -128,7 +128,7 @@ jobs:
         name: Checkout build system
         uses: actions/checkout@v2
         with:
-          repository: AlexVCaron/containers-scilus
+          repository: scilus/containers-scilus
           ref: develop
       -
         name: Resolve versioning from workflow inputs

--- a/containers/cmake.Dockerfile
+++ b/containers/cmake.Dockerfile
@@ -20,8 +20,8 @@ WORKDIR /tmp
 RUN mkdir -p cmake
 
 WORKDIR /tmp/cmake
-RUN wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz && \
-    tar -xzf cmake-${CMAKE_VERSION}.tar.gz
+ADD https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz cmake.tar.gz
+RUN tar -xzf cmake.tar.gz
 
 WORKDIR /tmp/cmake/cmake-${CMAKE_VERSION}
 RUN ./bootstrap && \

--- a/containers/nextflow.Dockerfile
+++ b/containers/nextflow.Dockerfile
@@ -15,7 +15,8 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
         wget && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget -qO- https://github.com/nextflow-io/nextflow/releases/download/v${NEXTFLOW_VERSION}/nextflow | bash && \
+ADD https://github.com/nextflow-io/nextflow/releases/download/v${NEXTFLOW_VERSION}/nextflow nextflow
+RUN bash nextflow && \
     chmod +x nextflow && \
     mv nextflow /usr/bin/nextflow && \
     apt-get -y remove \

--- a/containers/scilpy.context/scilpy.Dockerfile
+++ b/containers/scilpy.context/scilpy.Dockerfile
@@ -30,7 +30,7 @@ ADD https://github.com/scilus/scilpy/archive/${SCILPY_VERSION}.zip scilpy.zip
 RUN unzip scilpy.zip && \
     ZIP_NAME=$(echo ${SCILPY_VERSION} | tr / _) && \
     mv scilpy-${ZIP_NAME} scilpy && \
-    rm ${ZIP_NAME}.zip
+    rm scilpy.zip
 
 WORKDIR /scilpy
 RUN SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True python${PYTHON_VERSION} -m pip install -e . && \

--- a/containers/scilpy.context/scilpy.Dockerfile
+++ b/containers/scilpy.context/scilpy.Dockerfile
@@ -26,10 +26,11 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /
-RUN wget https://github.com/scilus/scilpy/archive/${SCILPY_VERSION}.zip && \
-    unzip ${SCILPY_VERSION}.zip && \
-    mv scilpy-${SCILPY_VERSION} scilpy && \
-    rm ${SCILPY_VERSION}.zip
+ADD https://github.com/scilus/scilpy/archive/${SCILPY_VERSION}.zip scilpy.zip
+RUN unzip scilpy.zip && \
+    ZIP_NAME=$(echo ${SCILPY_VERSION} | tr / _) && \
+    mv scilpy-${ZIP_NAME} scilpy && \
+    rm ${ZIP_NAME}.zip
 
 WORKDIR /scilpy
 RUN SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True python${PYTHON_VERSION} -m pip install -e . && \

--- a/containers/vtk-omesa.context/vtk-omesa.Dockerfile
+++ b/containers/vtk-omesa.context/vtk-omesa.Dockerfile
@@ -44,12 +44,12 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
 WORKDIR /
 ADD https://archive.mesa3d.org/mesa-${MESA_VERSION}.tar.gz mesa.tar.gz
 RUN tar -xzf mesa.tar.gz && \
-    rm mesa-${MESA_VERSION}.tar.gz
+    rm mesa.tar.gz
 
 WORKDIR ${VTK_BUILD_PATH}
 ADD https://gitlab.kitware.com/vtk/vtk/-/archive/v${VTK_VERSION}/vtk-v${VTK_VERSION}.tar.gz vtk.tar.gz
 RUN tar -xzf vtk.tar.gz && \
-    rm vtk-v${VTK_VERSION}.tar.gz
+    rm vtk.tar.gz
 
 WORKDIR /mesa-${MESA_VERSION}
 RUN ./configure --prefix=${MESA_INSTALL_PATH} \

--- a/containers/vtk-omesa.context/vtk-omesa.Dockerfile
+++ b/containers/vtk-omesa.context/vtk-omesa.Dockerfile
@@ -42,13 +42,13 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /
-RUN wget https://archive.mesa3d.org/mesa-${MESA_VERSION}.tar.gz && \
-    tar -xzf mesa-${MESA_VERSION}.tar.gz && \
+ADD https://archive.mesa3d.org/mesa-${MESA_VERSION}.tar.gz mesa.tar.gz
+RUN tar -xzf mesa.tar.gz && \
     rm mesa-${MESA_VERSION}.tar.gz
 
 WORKDIR ${VTK_BUILD_PATH}
-RUN wget https://gitlab.kitware.com/vtk/vtk/-/archive/v${VTK_VERSION}/vtk-v${VTK_VERSION}.tar.gz && \
-    tar -xzf vtk-v${VTK_VERSION}.tar.gz && \
+ADD https://gitlab.kitware.com/vtk/vtk/-/archive/v${VTK_VERSION}/vtk-v${VTK_VERSION}.tar.gz vtk.tar.gz
+RUN tar -xzf vtk.tar.gz && \
     rm vtk-v${VTK_VERSION}.tar.gz
 
 WORKDIR /mesa-${MESA_VERSION}


### PR DESCRIPTION
This PR contains two fixes to the build system :

- Redirection of the build system checkout to `scilus` instead of the fork
- Replace `wget` calls by `ADD` directives for easier cache handing from docker

Tested will all build targets and working !