### PR TITLE
Improve ants portability

### DIFF
--- a/containers/ants.Dockerfile
+++ b/containers/ants.Dockerfile
@@ -31,6 +31,8 @@ RUN cmake -DBUILD_SHARED_LIBS=OFF \
           -DBUILD_TESTING=OFF \
           -DRUN_LONG_TESTS=OFF \
           -DRUN_SHORT_TESTS=OFF \
+          -DSuperBuild_ANTS_C_OPTIMIZATION_FLAGS="-mtune=native -march=x86-64" \
+          -DSuperBuild_ANTS_CXX_OPTIMIZATION_FLAGS="-mtune=native -march=x86-64" \
           -DCMAKE_INSTALL_PREFIX=${ANTS_INSTALL_PATH} \
           ../ANTs && \
     [ -z "$ANTS_BUILD_NTHREADS" ] && \


### PR DESCRIPTION
See: https://github.com/ANTsX/ANTs/wiki/Compiling-ANTs-on-Linux-and-Mac-OS#compilation-fails-or-run-time-errors-occur-with-illegal-instruction-errors