### PR TITLE
Keep actions-runner-builder alive

### DIFF
--- a/.github/workflows/keep-cron-alive.yml
+++ b/.github/workflows/keep-cron-alive.yml
@@ -1,0 +1,13 @@
+name: Keep container build cron-jobs alive
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs every day at midnight
+jobs:
+  keep-cron-alive:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrisnar/keepalive-workflow@v2
+        with:
+          workflow_files: "actions-runner.builder.yml"
+          time_elapsed: "0"


### PR DESCRIPTION
By policy, Github disables any **scheduled workflow** after **60 days of inactivity on a repository**. Github defines it based on commits and conversations in PR, but workflow runs are not accounted.

This PR adds a simple workflow that **runs daily and reactivates the actions-runner build workflow only**, by configuration, so future ones can decide if they need the mechanism.