### PR TITLE
Update antsRegistration_affine_SyN.sh version to 1.2

### DIFF
--- a/docker-bake.override.hcl
+++ b/docker-bake.override.hcl
@@ -11,7 +11,7 @@ dmriqcpy-revision="0.1.7"
 scilpy-revision="2.2.1"
 
 ants-revision="v2.6.2"
-ants-affine-syn-revision="1.1"
+ants-affine-syn-revision="1.2"
 cmake-revision="v3.21.6"
 fsl-version="6.0.7.18.scilus.lean"
 fsl-installer-version="3.14.0"


### PR DESCRIPTION
Please at least update :dev with this. I still want to add "reproducible mode" before another tagged release.